### PR TITLE
Separate operator generation and building logic in scripts

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -45,6 +45,9 @@ RUN apt-get -q update && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
     GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports
 
+# TODO(mangelajo): the operator-sdk install guide recommends go get -d , but that doesn't pull
+# the sources where we expect. We need to figure out what's going on and remove the git clone
+# hack.
 RUN OP_FRAMEWORK="$GOPATH/src/github.com/operator-framework" && \
     mkdir -p $OP_FRAMEWORK && cd $OP_FRAMEWORK && \
     git clone https://github.com/operator-framework/operator-sdk && \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -14,7 +14,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} DAPPER_ENV=REPO DAPPE
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
-    GOPATH=/go GO111MODULE=on PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash GOFLAGS=-mod=vendor
+    GOPATH=/go GO111MODULE=on PATH=/go/bin:/usr/local/go/bin:/root/go/bin:${PATH} SHELL=/bin/bash GOFLAGS=-mod=vendor
 
 # Requirements:
 # Component      | Usage
@@ -32,7 +32,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
 # ginkgo         | tests
 # goimports      | code formatting
 RUN apt-get -q update && \
-    apt-get install -y gcc git curl docker.io && \
+    apt-get install -y gcc git curl docker.io mercurial make && \
     curl https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
     chmod a+x /usr/bin/kubectl && \
@@ -44,6 +44,12 @@ RUN apt-get -q update && \
     curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
     GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports
+
+RUN OP_FRAMEWORK="$GOPATH/src/github.com/operator-framework" && \
+    mkdir -p $OP_FRAMEWORK && cd $OP_FRAMEWORK && \
+    git clone https://github.com/operator-framework/operator-sdk && \
+    cd operator-sdk && git checkout 3a85983ecc72bea079973269db429292141d165a  && \
+    make tidy && GOFLAGS="" make install
 
 WORKDIR ${DAPPER_SOURCE}
 

--- a/operators/go/README.md
+++ b/operators/go/README.md
@@ -10,22 +10,15 @@ the Operator SDK. It also results in a clear, working example of how to use the
 Operator SDK to create additional operators (perhaps for future parts of
 Submariner).
 
-> ./gen_subm_operator.sh
+> cd ../../../
+> make codegen-operator
 
-#### Prerequisites
+That will run the operator sourcecode generation logic in ./gen_subm_operator.sh
 
-##### Kind
+### Builiding the operator
 
-The Operator SDK requires a running K8s cluster. This tooling uses Kind
-(Kubernetes in Docker) to deploy that cluster. You'll need to [install Kind][0]
-as a prerequisite for generating the Operator. Kind was chosen because it's
-currently the tooling used for deploying K8s clusters for Submariner CI.
-
-##### Operator SDK
-
-The SubM Operator generator script uses the Operator SDK tooling to create most
-of the Operator from recommended scaffolding. The [Operator SDK must be
-installed][1] as a prerequisite of the `gen_subm_operator.sh` script.
+> cd ../../..
+> make build-operator
 
 ### Deploying Submariner using the Operator
 
@@ -37,6 +30,3 @@ the `deploytool` flag to the standard `make` commands.
 
 A large set of verifications for the Operator and the resulting Submariner
 deployment will automatically run during and after the deployment.
-
-[0]: https://kind.sigs.k8s.io/docs/user/quick-start/
-[1]: https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md

--- a/operators/go/build_subm_operator.sh
+++ b/operators/go/build_subm_operator.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+
+version=${1:-dev}
+push_image=${2:-false}
+op_gen_dir=$(pwd)
+op_out_dir=$op_gen_dir/submariner-operator
+
+function build_subm_operator() {
+
+  pushd $op_out_dir
+  go mod vendor
+
+  operator-sdk build quay.io/submariner/submariner-operator:$version --verbose
+  if [[ $push_image = true ]]; then
+    docker push quay.io/submariner/submariner-operator:$version
+  else
+    echo "Skipping pushing SubM Operator image to Quay"
+  fi
+
+  popd
+}
+
+build_subm_operator
+

--- a/operators/go/build_subm_operator.sh
+++ b/operators/go/build_subm_operator.sh
@@ -3,23 +3,18 @@ set -ex
 
 version=${1:-dev}
 push_image=${2:-false}
-op_gen_dir=$(pwd)
-op_out_dir=$op_gen_dir/submariner-operator
 
-function build_subm_operator() {
+cd $(pwd)/submariner-operator
 
-  pushd $op_out_dir
-  go mod vendor
+go mod vendor
 
-  operator-sdk build quay.io/submariner/submariner-operator:$version --verbose
-  if [[ $push_image = true ]]; then
-    docker push quay.io/submariner/submariner-operator:$version
-  else
-    echo "Skipping pushing SubM Operator image to Quay"
-  fi
+operator-sdk build quay.io/submariner/submariner-operator:$version --verbose
 
-  popd
-}
+if [[ $push_image = true ]]; then
+  docker push quay.io/submariner/submariner-operator:$version
+else
+  echo "Skipping pushing SubM Operator image to Quay"
+fi
 
-build_subm_operator
+
 

--- a/operators/go/deploy-operator-local.yml
+++ b/operators/go/deploy-operator-local.yml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: submariner-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: submariner-operator
+  template:
+    metadata:
+      labels:
+        name: submariner-operator
+    spec:
+      serviceAccountName: submariner-operator
+      containers:
+        - name: submariner-operator
+          image: submariner-operator:local
+          command:
+          - submariner-operator
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "submariner-operator"

--- a/operators/go/gen_subm_operator.sh
+++ b/operators/go/gen_subm_operator.sh
@@ -15,14 +15,6 @@ op_gen_dir=$(pwd)
 op_out_dir=$op_gen_dir/submariner-operator
 
 function setup_prereqs(){
-  if ! command -v dep; then
-    # Install dep
-    curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-
-    # Make sure go/bin is in path
-    command -v dep
-  fi
-
   # NB: There must be a running K8s cluster pointed at by the exported KUBECONFIG
   # for operator-sdk to work (although this dependency doesn't make sense)
   kind delete cluster || true # make sure any pre-existing cluster is removed, otherwise it fails in dapper

--- a/scripts/build-operator
+++ b/scripts/build-operator
@@ -1,10 +1,5 @@
 #!/bin/bash
 
 source $(dirname $0)/lib/debug_functions
-
-cd $(dirname $0)
-
-GOFLAGS=""
-
-cd ../operators/go
+cd $(dirname $0)/../operators/go
 ./build_subm_operator.sh $VERSION

--- a/scripts/build-operator
+++ b/scripts/build-operator
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source $(dirname $0)/lib/debug_functions
+
+cd $(dirname $0)
+
+GOFLAGS=""
+
+cd ../operators/go
+./build_subm_operator.sh $VERSION

--- a/scripts/codegen-operator
+++ b/scripts/codegen-operator
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 source $(dirname $0)/lib/debug_functions
+cd $(dirname $0)/../operators/go
 
-cd $(dirname $0)
-
-GOFLAGS=""
-
-cd ../operators/go
+# generation script does not expect vendoring mode
+export GOFLAGS=""
 ./gen_subm_operator.sh

--- a/scripts/codegen-operator
+++ b/scripts/codegen-operator
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source $(dirname $0)/lib/debug_functions
+
+cd $(dirname $0)
+
+GOFLAGS=""
+
+cd ../operators/go
+./gen_subm_operator.sh

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -5,6 +5,11 @@ source $(dirname $0)/lib/debug_functions
 
 cd $(dirname $0)
 
+if [[ $5 = operator ]]; then
+   test -d ../operators/go/submariner-operator || ./codegen-operator
+   # ./build-operator
+fi
+
 if [[ $1 = clean ]]; then
     ./../scripts/kind-e2e/e2e.sh clean
 else

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -7,7 +7,7 @@ cd $(dirname $0)
 
 if [[ $5 = operator ]]; then
    test -d ../operators/go/submariner-operator || ./codegen-operator
-   # ./build-operator
+   ./build-operator
 fi
 
 if [[ $1 = clean ]]; then

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -3,8 +3,6 @@ set -em
 
 source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
 
-deploytool=$5
-
 ### Functions ###
 
 function kind_clusters() {
@@ -200,7 +198,7 @@ function kind_import_images() {
     docker tag rancher/submariner:dev submariner:local
     docker tag rancher/submariner-route-agent:dev submariner-route-agent:local
 
-    if [[ $deploytool = operator ]]; then
+    if [[ "$deploy_operator" = true ]]; then
        docker tag quay.io/submariner/submariner-operator:dev submariner-operator:local
     fi
 
@@ -208,7 +206,7 @@ function kind_import_images() {
         echo "Loading submariner images in to cluster${i}..."
         kind --name cluster${i} load docker-image submariner:local
         kind --name cluster${i} load docker-image submariner-route-agent:local
-        if [[ $deploytool = operator ]]; then
+        if [[ "$deploy_operator" = true ]]; then
              kind --name cluster${i} load docker-image submariner-operator:local
 	fi
     done
@@ -457,7 +455,7 @@ if [ "$deploy_operator" = true ]; then
 
     deploy_netshoot_cluster2
     deploy_nginx_cluster3
-elif [[ $deploytool = helm ]]; then
+elif [[ $5 = helm ]]; then
     helm=true
     setup_cluster2_gateway
     setup_cluster3_gateway

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -3,6 +3,8 @@ set -em
 
 source $(git rev-parse --show-toplevel)/scripts/lib/debug_functions
 
+deploytool=$5
+
 ### Functions ###
 
 function kind_clusters() {
@@ -198,10 +200,17 @@ function kind_import_images() {
     docker tag rancher/submariner:dev submariner:local
     docker tag rancher/submariner-route-agent:dev submariner-route-agent:local
 
+    if [[ $deploytool = operator ]]; then
+       docker tag quay.io/submariner/submariner-operator:dev submariner-operator:local
+    fi
+
     for i in 2 3; do
         echo "Loading submariner images in to cluster${i}..."
         kind --name cluster${i} load docker-image submariner:local
         kind --name cluster${i} load docker-image submariner-route-agent:local
+        if [[ $deploytool = operator ]]; then
+             kind --name cluster${i} load docker-image submariner-operator:local
+	fi
     done
 }
 
@@ -448,7 +457,7 @@ if [ "$deploy_operator" = true ]; then
 
     deploy_netshoot_cluster2
     deploy_nginx_cluster3
-elif [[ $5 = helm ]]; then
+elif [[ $deploytool = helm ]]; then
     helm=true
     setup_cluster2_gateway
     setup_cluster3_gateway

--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -5,8 +5,6 @@ if [ "${0##*/}" = "lib_operator_deploy_subm.sh" ]; then
 fi
 
 openapi_checks_enabled=false
-subm_ns=operators
-subm_broker_ns=submariner-k8s-broker
 subm_op_src_dir=$(realpath ../operators/go/submariner-operator)
 subm_op_dir=$subm_op_src_dir
 

--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -5,30 +5,10 @@ if [ "${0##*/}" = "lib_operator_deploy_subm.sh" ]; then
 fi
 
 openapi_checks_enabled=false
-
-# FIXME: Extract these into a setup prereqs function
-if ! command -v go; then
-  curl https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz -o go.tar.gz
-  tar -xf go.tar.gz
-  cp go /usr/local/bin/go
-fi
-
-if ! command -v dep; then
-  # Install dep
-  curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-
-  # Make sure go/bin is in path
-  command -v dep
-fi
-
-GOPATH=$HOME/go
-subm_op_dir=$GOPATH/src/github.com/submariner-operator/submariner-operator
-subm_op_src_dir=../operators/go/submariner-operator
-mkdir -p $subm_op_dir
-
-cp -a $subm_op_src_dir/. $subm_op_dir/
-
-export GO111MODULE=on
+subm_ns=operators
+subm_broker_ns=submariner-k8s-broker
+subm_op_src_dir=$(realpath ../operators/go/submariner-operator)
+subm_op_dir=$subm_op_src_dir
 
 function create_resource_if_missing() {
   resource_type=$1
@@ -158,7 +138,7 @@ function deploy_subm_operator() {
   create_resource_if_missing rolebinding submariner-operator deploy/role_binding.yaml
 
   # Create SubM Operator deployment if it doesn't exist
-  create_resource_if_missing deployment submariner-operator deploy/operator.yaml
+  create_resource_if_missing deployment submariner-operator ../deploy-operator-local.yml
 
   # Wait for SubM Operator pod to be ready
   kubectl wait --for=condition=Ready pods -l name=submariner-operator --timeout=120s --namespace=$subm_ns


### PR DESCRIPTION
The scripts are: codegen-operator and build-operator, we rely
on a stable dapper based environment to be able to generate
and build across the team without issues.

The dapper image now installs operator-sdk from an specific
master commit it's know for us to work.

To regenerate the operators/go/submariner-operator:

    make codegen-operator

To build the operator container image:

    make build-operator

This PR contains a second commit which will use the build-operator
images when testing e2e, instead of using the ones from quay.