### PR TITLE
Check that the library files are sourced

### DIFF
--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -1,4 +1,8 @@
-set -ex
+# This should only be sourced
+if [ "${0##*/}" = "lib_operator_deploy_subm.sh" ]; then
+    echo "Don't run me, source me" >&2
+    exit 1
+fi
 
 openapi_checks_enabled=false
 

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -1,4 +1,8 @@
-set -ex
+# This should only be sourced
+if [ "${0##*/}" = "lib_operator_verify_subm.sh" ]; then
+    echo "Don't run me, source me" >&2
+    exit 1
+fi
 
 function verify_subm_gateway_label() {
   kubectl get node $context-worker -o jsonpath='{.metadata.labels}' | grep submariner.io/gateway:true


### PR DESCRIPTION
This prevents the e2e library files from being run directly.
It also drops "set -ex" since such options should be set in the main
script, not included scripts.

Closes: HYCLD-263
Signed-off-by: Stephen Kitt <skitt@redhat.com>