### PR TITLE
Fix Engine container permissions to work w/ master

### DIFF
--- a/operators/go/submariner_controller.go.nolint
+++ b/operators/go/submariner_controller.go.nolint
@@ -134,8 +134,12 @@ func newPodForCR(cr *submarinerv1alpha1.Submariner) *corev1.Pod {
 		"app": "submariner-engine",
 	}
 
-	// Create SecurityContext for Pod
-	security_context_add_net_admin := corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_ADMIN"}}}
+	// Create privilaged security context for Engine pod
+	// FIXME: Seems like these have to be a var, so can pass pointer to bool var to SecurityContext. Cleaner option?
+	allow_privilege_escalation := true
+	privileged := true
+	run_as_non_root := false
+	security_context_all_caps_privilaged := corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"ALL"}}, AllowPrivilegeEscalation: &allow_privilege_escalation, Privileged: &privileged, RunAsNonRoot: &run_as_non_root}
 
 	// Create Pod
 	return &corev1.Pod{
@@ -152,7 +156,7 @@ func newPodForCR(cr *submarinerv1alpha1.Submariner) *corev1.Pod {
 					Image: "submariner:local",
 					// TODO: Use var here
 					Command:         []string{"submariner.sh"},
-					SecurityContext: &security_context_add_net_admin,
+					SecurityContext: &security_context_all_caps_privilaged,
 					Env: []corev1.EnvVar{
 						{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.SubmarinerNamespace},
 						{Name: "SUBMARINER_CLUSTERCIDR", Value: cr.Spec.SubmarinerClustercidr},

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -199,12 +199,9 @@ function verify_subm_engine_pod() {
 
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o json
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..image}' | grep submariner:local
-  if [[ $helm = true ]]; then
-    kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..securityContext.capabilities.add}' | grep ALL
-  fi
-  if [[ $operator  = true ]]; then
-    kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..securityContext.capabilities.add}' | grep NET_ADMIN
-  fi
+  kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..securityContext.capabilities.add}' | grep ALL
+  kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..securityContext.allowPrivilegeEscalation}' | grep "true"
+  kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..securityContext.privileged}' | grep "true"
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..command}' | grep submariner.sh
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}'
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_NAMESPACE value:$subm_ns"


### PR DESCRIPTION
This gets the Engine pod past "Read only fs" failure on master commits
equal to and after 0919214bf5595bd735583cdd60234c9613663e35.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>