### PR TITLE
Add waits for secret creation before verifications

### DIFF
--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -371,7 +371,19 @@ function verify_subm_routeagent_container() {
 }
 
 function verify_subm_broker_secrets() {
-  # Show all SubM secrets
+  # Wait for secrets to be created
+  SECONDS="0"
+  while ! kubectl get secret -n $subm_broker_ns | grep -q submariner-; do
+    if [ $SECONDS -gt 30 ]; then
+        echo "Timeout waiting for SubM Secret creation"
+        exit 1
+    else
+        ((SECONDS+=2))
+        sleep 2
+    fi
+  done
+
+  # Show all SubM broker secrets
   kubectl get secrets -n $subm_broker_ns
 
   subm_broker_secret_name=$(kubectl get secrets -n $subm_broker_ns -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$broker_deployment_name-client')].metadata.name}")
@@ -396,6 +408,18 @@ function verify_subm_broker_secrets() {
 }
 
 function verify_subm_engine_secrets() {
+  # Wait for secrets to be created
+  SECONDS="0"
+  while ! kubectl get secret -n $subm_ns | grep -q submariner-; do
+    if [ $SECONDS -gt 30 ]; then
+        echo "Timeout waiting for SubM Secret creation"
+        exit 1
+    else
+        ((SECONDS+=2))
+        sleep 2
+    fi
+  done
+
   # Show all SubM secrets
   kubectl get secrets -n $subm_ns
 
@@ -429,6 +453,18 @@ function verify_subm_engine_secrets() {
 }
 
 function verify_subm_routeagent_secrets() {
+  # Wait for secrets to be created
+  SECONDS="0"
+  while ! kubectl get secret -n $subm_ns | grep -q submariner-; do
+    if [ $SECONDS -gt 30 ]; then
+        echo "Timeout waiting for SubM Secret creation"
+        exit 1
+    else
+        ((SECONDS+=2))
+        sleep 2
+    fi
+  done
+
   # Show all SubM secrets
   kubectl get secrets -n $subm_ns
 


### PR DESCRIPTION
Per feedback from Noam, and I've also seen it myself, the timing can be
such that the secret verifications fail because the secret doesn't quite
exist yet.

There is no "condition:Ready" on Secret objects as there are is on Pods,
so we can't use the normal `wait --for=condition=Ready secrets --all`
here.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>