### PR TITLE
Make routeagent deploy a DaemonSet

### DIFF
--- a/operators/go/routeagent_controller.go.nolint
+++ b/operators/go/routeagent_controller.go.nolint
@@ -3,6 +3,8 @@ package routeagent
 import (
 	"context"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	submarinerv1alpha1 "github.com/submariner-operator/submariner-operator/pkg/apis/submariner/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -92,19 +94,20 @@ func (r *ReconcileRouteagent) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Define a new Pod object
-	pod := newPodForCR(instance)
+	daemonSet := newRouteAgentDaemonSet(instance)
 
 	// Set Routeagent instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
+	if err := controllerutil.SetControllerReference(instance, daemonSet, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// Check if this Pod already exists
-	found := &corev1.Pod{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
+	found := &appsv1.DaemonSet{}
+
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: daemonSet.Name, Namespace: daemonSet.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
-		err = r.client.Create(context.TODO(), pod)
+		reqLogger.Info("Creating a new DaemonSet", "DaemonSet.Namespace", daemonSet.Namespace, "DaemonSet.Name", daemonSet.Name)
+		err = r.client.Create(context.TODO(), daemonSet)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -116,58 +119,70 @@ func (r *ReconcileRouteagent) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Pod already exists - don't requeue
-	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
+	reqLogger.Info("Skip reconcile: DaemonSet already exists", "DaemonSet.Namespace", found.Namespace, "DaemonSet.Name", found.Name)
 	return reconcile.Result{}, nil
 }
 
-// newPodForCR returns a busybox pod with the same name/namespace as the cr
-func newPodForCR(cr *submarinerv1alpha1.Routeagent) *corev1.Pod {
+func newRouteAgentDaemonSet(cr *submarinerv1alpha1.Routeagent) *appsv1.DaemonSet {
 	labels := map[string]string{
+		"app":       "submariner-routeagent",
+		"component": "routeagent",
+	}
+
+	matchLabels := map[string]string{
 		"app": "submariner-routeagent",
 	}
 
-	// Create SecurityContext for Pod
-	// FIXME: Does this really need to be ALL, vs just NET_ADMIN? The current Helm-based deployment gives ALL.
-	//security_context_net_admin_cap := corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_ADMIN"}}}
-	// FIXME: Seems like these have to be a var, so can pass pointer to bool var to SecurityContext. Cleaner option?
 	allow_privilege_escalation := true
 	privileged := true
-	// TODO: Verify all these permissions are needed
-	security_context_all_cap_allow_escal := corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"ALL"}}, AllowPrivilegeEscalation: &allow_privilege_escalation, Privileged: &privileged}
+	security_context_all_cap_allow_escal := corev1.SecurityContext{
+		Capabilities:             &corev1.Capabilities{Add: []corev1.Capability{"ALL"}},
+		AllowPrivilegeEscalation: &allow_privilege_escalation,
+		Privileged:               &privileged}
 
-	return &corev1.Pod{
+	routeAgentDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-pod",
 			Namespace: cr.Namespace,
+			Name:      "submariner-routeagent",
 			Labels:    labels,
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name: "submariner-routeagent",
-					// TODO: Use var here
-					Image: "submariner-route-agent:local",
-					// FIXME: Should be entrypoint script, find/use correct file for routeagent
-					Command:         []string{"submariner-route-agent.sh"},
-					SecurityContext: &security_context_all_cap_allow_escal,
-					VolumeMounts: []corev1.VolumeMount{
-						{Name: "host-slash", MountPath: "/host", ReadOnly: true},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: matchLabels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "submariner-routeagent",
+							// TODO: Use var here
+							Image: "submariner-route-agent:local",
+							// FIXME: Should be entrypoint script, find/use correct file for routeagent
+							Command:         []string{"submariner-route-agent.sh"},
+							SecurityContext: &security_context_all_cap_allow_escal,
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "host-slash", MountPath: "/host", ReadOnly: true},
+							},
+							Env: []corev1.EnvVar{
+								{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
+								{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
+								{Name: "SUBMARINER_DEBUG", Value: cr.Spec.Debug},
+								{Name: "SUBMARINER_CLUSTERCIDR", Value: cr.Spec.ClusterCIDR},
+								{Name: "SUBMARINER_SERVICECIDR", Value: cr.Spec.ServiceCIDR},
+							},
+						},
 					},
-					Env: []corev1.EnvVar{
-						{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
-						{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
-						{Name: "SUBMARINER_DEBUG", Value: cr.Spec.Debug},
-						{Name: "SUBMARINER_CLUSTERCIDR", Value: cr.Spec.ClusterCIDR},
-						{Name: "SUBMARINER_SERVICECIDR", Value: cr.Spec.ServiceCIDR},
+					// TODO: Use SA submariner-routeagent or submariner?
+					ServiceAccountName: "submariner-operator",
+					HostNetwork:        true,
+					Volumes: []corev1.Volume{
+						{Name: "host-slash", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
 					},
 				},
 			},
-			// TODO: Use SA submariner-routeagent or submariner?
-			ServiceAccountName: "submariner-operator",
-			HostNetwork:        true,
-			Volumes: []corev1.Volume{
-				{Name: "host-slash", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
-			},
 		},
 	}
+
+	return routeAgentDaemonSet
 }

--- a/operators/go/routeagent_controller.go.nolint
+++ b/operators/go/routeagent_controller.go.nolint
@@ -93,7 +93,6 @@ func (r *ReconcileRouteagent) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	// Define a new Pod object
 	daemonSet := newRouteAgentDaemonSet(instance)
 
 	// Set Routeagent instance as the owner and controller
@@ -101,9 +100,7 @@ func (r *ReconcileRouteagent) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	// Check if this Pod already exists
 	found := &appsv1.DaemonSet{}
-
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: daemonSet.Name, Namespace: daemonSet.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		reqLogger.Info("Creating a new DaemonSet", "DaemonSet.Namespace", daemonSet.Namespace, "DaemonSet.Name", daemonSet.Name)
@@ -112,13 +109,11 @@ func (r *ReconcileRouteagent) Reconcile(request reconcile.Request) (reconcile.Re
 			return reconcile.Result{}, err
 		}
 
-		// Pod created successfully - don't requeue
 		return reconcile.Result{}, nil
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	// Pod already exists - don't requeue
 	reqLogger.Info("Skip reconcile: DaemonSet already exists", "DaemonSet.Namespace", found.Namespace, "DaemonSet.Name", found.Name)
 	return reconcile.Result{}, nil
 }
@@ -155,8 +150,7 @@ func newRouteAgentDaemonSet(cr *submarinerv1alpha1.Routeagent) *appsv1.DaemonSet
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: "submariner-routeagent",
-							// TODO: Use var here
+							Name:  "submariner-routeagent",
 							Image: "submariner-route-agent:local",
 							// FIXME: Should be entrypoint script, find/use correct file for routeagent
 							Command:         []string{"submariner-route-agent.sh"},

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -449,6 +449,8 @@ if [ "$deploy_operator" = true ]; then
       deploy_routeagent_cr
       # Verify Routeagent CR
       verify_routeagent_cr
+      # Verify SubM Routeagent DaemonSet
+      verify_subm_routeagent_daemonset
       # Verify SubM Routeagent Pods
       verify_subm_routeagent_pod
       # Verify SubM Routeagent container
@@ -471,6 +473,7 @@ elif [[ $5 = helm ]]; then
       subm_ns=submariner
 
       verify_subm_engine_pod
+      verify_subm_routeagent_daemonset
       verify_subm_routeagent_pod
       verify_subm_engine_container
       verify_subm_routeagent_container

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -245,6 +245,12 @@ function verify_subm_engine_pod() {
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.metadata.namespace}' | grep $subm_ns
 }
 
+function verify_subm_routeagent_daemonset() {
+  # Simple verification to ensure that the routeagent daemonset has been created and becomes ready
+  kubectl wait --for=condition=Ready DaemonSets -l app=$routeagent_deployment_name --timeout=120s --namespace=$subm_ns
+  # the pod-checking function will do the rest
+}
+
 function verify_subm_routeagent_pod() {
   kubectl wait --for=condition=Ready pods -l app=$routeagent_deployment_name --timeout=120s --namespace=$subm_ns
 


### PR DESCRIPTION
DaemonSets are used to deploy a pod on each worker node of the cluster,
and it's the same object used on the helm charts.

This fixes the src-ip issues on e2e tests.