### PR TITLE
Add shebangs for scripts

### DIFF
--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This should only be sourced
 if [ "${0##*/}" = "lib_operator_deploy_subm.sh" ]; then
     echo "Don't run me, source me" >&2

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This should only be sourced
 if [ "${0##*/}" = "lib_operator_verify_subm.sh" ]; then
     echo "Don't run me, source me" >&2


### PR DESCRIPTION
This is strictly speaking unnecessary, since these are designed to be
sourced; but having a shebang helps with shellcode analysis.

Signed-off-by: Stephen Kitt <skitt@redhat.com>