### PR TITLE
Use same IPSec NATT/IKE Port var defaults as Helm

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -237,8 +237,8 @@ function create_subm_vars() {
   subm_debug=false
   subm_broker=k8s
   ce_ipsec_debug=false
-  ce_ipsec_ikeport=501
-  ce_ipsec_nattport=4501
+  ce_ipsec_ikeport=500
+  ce_ipsec_nattport=4500
   # FIXME: This seems to be empty with default Helm deploys?
   # FIXME: Clarify broker token vs sumb psk
   subm_token=$SUBMARINER_BROKER_TOKEN


### PR DESCRIPTION
This gets verifications passing for both Helm and Operator-based
deployments again.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>