### PR TITLE
Fix differences between helm and operator on the DaemonSet

### DIFF
--- a/operators/go/routeagent_controller.go.nolint
+++ b/operators/go/routeagent_controller.go.nolint
@@ -130,15 +130,22 @@ func newRouteAgentDaemonSet(cr *submarinerv1alpha1.Routeagent) *appsv1.DaemonSet
 
 	allow_privilege_escalation := true
 	privileged := true
+	readOnlyFileSystem := false
+	runAsNonRoot := false
 	security_context_all_cap_allow_escal := corev1.SecurityContext{
 		Capabilities:             &corev1.Capabilities{Add: []corev1.Capability{"ALL"}},
 		AllowPrivilegeEscalation: &allow_privilege_escalation,
-		Privileged:               &privileged}
+		Privileged:               &privileged,
+		ReadOnlyRootFilesystem:   &readOnlyFileSystem,
+		RunAsNonRoot:             &runAsNonRoot,
+	}
+
+	terminationGracePeriodSeconds := int64(0)
 
 	routeAgentDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cr.Namespace,
-			Name:      "submariner-routeagent",
+			Name:      "routeagent",
 			Labels:    labels,
 		},
 		Spec: appsv1.DaemonSetSpec{
@@ -148,6 +155,7 @@ func newRouteAgentDaemonSet(cr *submarinerv1alpha1.Routeagent) *appsv1.DaemonSet
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					Containers: []corev1.Container{
 						{
 							Name:  "submariner-routeagent",


### PR DESCRIPTION
@mkolesnik  found some important differences between how helm and
the operator deploy the routeagent daemonset in terms of privileges
and termination details.

Still the service account detail remains.

This should also fix an error checking the daemonset to helm
due to creating it with different names "routeagent" vs "submariner-routeagent"