### PR TITLE
Use the Go proxy

### DIFF
--- a/operators/go/gen_subm_operator.sh
+++ b/operators/go/gen_subm_operator.sh
@@ -7,6 +7,10 @@ export GOROOT
 export GO111MODULE=on
 GOPATH=$HOME/go
 
+# Rely on the Go proxy to accelerate downloads and avoid problems with
+# disappearing repositories
+export GOPROXY=https://proxy.golang.org
+
 version=0.0.1
 push_image=false
 op_dir=$GOPATH/src/github.com/submariner-operator/submariner-operator


### PR DESCRIPTION
This makes downloading the dependencies much faster in my experience,
and avoids problems with disappearing repositories.

Signed-off-by: Stephen Kitt <skitt@redhat.com>