### PR TITLE
Remove unused/duplicate token in SubM Operator

### DIFF
--- a/operators/go/gen_subm_operator.sh
+++ b/operators/go/gen_subm_operator.sh
@@ -63,7 +63,6 @@ function add_subm_engine_to_operator() {
   sed -i '/SubmarinerSpec struct/a \ \ Namespace string `json:"namespace"`' $types_file
   sed -i '/SubmarinerSpec struct/a \ \ ClusterCIDR string `json:"clusterCIDR"`' $types_file
   sed -i '/SubmarinerSpec struct/a \ \ ServiceCIDR string `json:"serviceCIDR"`' $types_file
-  sed -i '/SubmarinerSpec struct/a \ \ Token string `json:"token"`' $types_file
   sed -i '/SubmarinerSpec struct/a \ \ ClusterID string `json:"clusterID"`' $types_file
   sed -i '/SubmarinerSpec struct/a \ \ ColorCodes string `json:"colorCodes"`' $types_file
   sed -i '/SubmarinerSpec struct/a \ \ Debug string `json:"debug"`' $types_file

--- a/operators/go/submariner_controller.go.nolint
+++ b/operators/go/submariner_controller.go.nolint
@@ -162,7 +162,6 @@ func newPodForCR(cr *submarinerv1alpha1.Submariner) *corev1.Pod {
 						{Name: "SUBMARINER_NAMESPACE", Value: cr.Spec.Namespace},
 						{Name: "SUBMARINER_CLUSTERCIDR", Value: cr.Spec.ClusterCIDR},
 						{Name: "SUBMARINER_SERVICECIDR", Value: cr.Spec.ServiceCIDR},
-						{Name: "SUBMARINER_TOKEN", Value: cr.Spec.Token},
 						{Name: "SUBMARINER_CLUSTERID", Value: cr.Spec.ClusterID},
 						{Name: "SUBMARINER_COLORCODES", Value: cr.Spec.ColorCodes},
 						{Name: "SUBMARINER_DEBUG", Value: cr.Spec.Debug},

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -239,9 +239,6 @@ function create_subm_vars() {
   ce_ipsec_debug=false
   ce_ipsec_ikeport=500
   ce_ipsec_nattport=4500
-  # FIXME: This seems to be empty with default Helm deploys?
-  # FIXME: Clarify broker token vs sumb psk
-  subm_token=$SUBMARINER_BROKER_TOKEN
 
   subm_ns=operators
   subm_broker_ns=submariner-k8s-broker

--- a/scripts/kind-e2e/lib_operator_deploy_subm.sh
+++ b/scripts/kind-e2e/lib_operator_deploy_subm.sh
@@ -175,7 +175,6 @@ function create_subm_cr() {
     sed -i "/spec:/a \ \ serviceCIDR: $serviceCIDR_cluster3" $cr_file
     sed -i "/spec:/a \ \ clusterCIDR: $clusterCIDR_cluster3" $cr_file
   fi
-  sed -i "/spec:/a \ \ token: $subm_token" $cr_file
   sed -i "/spec:/a \ \ clusterID: $context" $cr_file
   sed -i "/spec:/a \ \ colorCodes: $subm_colorcodes" $cr_file
   # NB: Quoting bool-like vars is required or Go will type as bool and fail when set as env vars as strs

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -58,7 +58,6 @@ function verify_subm_crd() {
     kubectl get crd $crd_name -o jsonpath='{.spec.validation.openAPIV3Schema.properties.spec.required}' | grep submarinerDebug
     kubectl get crd $crd_name -o jsonpath='{.spec.validation.openAPIV3Schema.properties.spec.required}' | grep submarinerColorcodes
     kubectl get crd $crd_name -o jsonpath='{.spec.validation.openAPIV3Schema.properties.spec.required}' | grep submarinerClusterid
-    kubectl get crd $crd_name -o jsonpath='{.spec.validation.openAPIV3Schema.properties.spec.required}' | grep submarinerToken
     kubectl get crd $crd_name -o jsonpath='{.spec.validation.openAPIV3Schema.properties.spec.required}' | grep submarinerServicecidr
     kubectl get crd $crd_name -o jsonpath='{.spec.validation.openAPIV3Schema.properties.spec.required}' | grep submarinerClustercidr
     kubectl get crd $crd_name -o jsonpath='{.spec.validation.openAPIV3Schema.properties.spec.required}' | grep submarinerNamespace
@@ -159,7 +158,6 @@ function verify_subm_cr() {
     kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.serviceCIDR}' | grep $serviceCIDR_cluster3
     kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.clusterCIDR}' | grep $clusterCIDR_cluster3
   fi
-  kubectl get submariner $deployment_name --namespace=$subm_ns -o jsonpath='{.spec.token}' | grep $subm_token
 }
 
 function verify_routeagent_cr() {
@@ -221,12 +219,6 @@ function verify_subm_engine_pod() {
   elif [[ $context = cluster3 ]]; then
     kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_SERVICECIDR value:$serviceCIDR_cluster3"
     kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_CLUSTERCIDR value:$clusterCIDR_cluster3"
-  fi
-  if [ "$deploy_operator" = true ]; then
-    kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_TOKEN value:$subm_token"
-  else
-    # FIXME: This token value is null with default Helm deploy
-    kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_TOKEN"
   fi
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_CLUSTERID value:$context"
   kubectl get pod $subm_engine_pod_name --namespace=$subm_ns -o jsonpath='{.spec.containers..env}' | grep "name:SUBMARINER_COLORCODES value:$subm_colorcodes"
@@ -368,12 +360,6 @@ function verify_subm_engine_container() {
     kubectl exec -it $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_SERVICECIDR=$serviceCIDR_cluster3"
     kubectl exec -it $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_CLUSTERCIDR=$clusterCIDR_cluster3"
   fi
-  if [ "$deploy_operator" = true ]; then
-    kubectl exec -it $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_TOKEN=$subm_token"
-  else
-    # FIXME: This is null for Helm-based deploys
-    kubectl exec -it $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_TOKEN="
-  fi
   kubectl exec -it $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_COLORCODES=$subm_colorcode"
   kubectl exec -it $subm_engine_pod_name --namespace=$subm_ns -- env | grep "SUBMARINER_NATENABLED=$natEnabled"
   # FIXME: This fails on redeploys
@@ -464,7 +450,6 @@ function verify_subm_broker_secrets() {
   kubectl get secret $subm_broker_secret_name -n $subm_broker_ns -o jsonpath='{.metadata.namespace}' | grep $subm_broker_ns
   # Must use this jsonpath notation to access key with dot.in.name
   kubectl get secret $subm_broker_secret_name -n $subm_broker_ns -o "jsonpath={.data['ca\.crt']}" | grep $SUBMARINER_BROKER_CA
-  kubectl get secret $subm_broker_secret_name -n $subm_broker_ns -o jsonpath='{.data.token}' | base64 --decode | grep $SUBMARINER_BROKER_TOKEN
 }
 
 function verify_subm_engine_secrets() {
@@ -508,8 +493,6 @@ function verify_subm_engine_secrets() {
   # FIXME: There seems to be a strange error where these substantially match, but eventually actually are different
   kubectl get secret $subm_engine_secret_name -n $subm_ns -o "jsonpath={.data['ca\.crt']}" | grep ${SUBMARINER_BROKER_CA:0:50}
   #kubectl get secret $subm_engine_secret_name -n $subm_ns -o "jsonpath={.data['ca\.crt']}" | grep ${SUBMARINER_BROKER_CA:0:161}
-  kubectl get secret $subm_engine_secret_name -n $subm_ns -o jsonpath='{.data.token}' | base64 --decode | grep ${SUBMARINER_BROKER_TOKEN:0:50}
-  #kubectl get secret $subm_engine_secret_name -n $subm_ns -o jsonpath='{.data.token}' | base64 --decode | grep ${SUBMARINER_BROKER_TOKEN:0:149}
 }
 
 function verify_subm_routeagent_secrets() {
@@ -554,6 +537,4 @@ function verify_subm_routeagent_secrets() {
   # FIXME: There seems to be a strange error where these substantially match, but eventually actually are different
   kubectl get secret $subm_routeagent_secret_name -n $subm_ns -o "jsonpath={.data['ca\.crt']}" | grep ${SUBMARINER_BROKER_CA:0:50}
   #kubectl get secret $subm_routeagent_secret_name -n $subm_ns -o "jsonpath={.data['ca\.crt']}" | grep ${SUBMARINER_BROKER_CA:0:162}
-  kubectl get secret $subm_routeagent_secret_name -n $subm_ns -o jsonpath='{.data.token}' | base64 --decode | grep ${SUBMARINER_BROKER_TOKEN:0:50}
-  #kubectl get secret $subm_routeagent_secret_name -n $subm_ns -o jsonpath='{.data.token}' | base64 --decode | grep ${SUBMARINER_BROKER_TOKEN:0:149}
 }


### PR DESCRIPTION
Per discussion on
https://github.com/dfarrell07/submariner/pull/18,
this patch removes old/duplicate `SubmarinerToken`
or `Token` and only use `BrokerK8sApiServerToken`.

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>