### PR TITLE
Stop doing codegen as source code is checked in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 submariner-engine
 submariner-route-agent
 .dapper
-bin
+/bin
 dist
 output
 strongswan

--- a/operators/go/submariner-operator/build/bin/entrypoint
+++ b/operators/go/submariner-operator/build/bin/entrypoint
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+# This is documented here:
+# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
+
+if ! whoami &>/dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-submariner-operator}:x:$(id -u):$(id -g):${USER_NAME:-submariner-operator} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec ${OPERATOR} $@

--- a/operators/go/submariner-operator/build/bin/user_setup
+++ b/operators/go/submariner-operator/build/bin/user_setup
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -x
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+mkdir -p ${HOME}
+chown ${USER_UID}:0 ${HOME}
+chmod ug+rwx ${HOME}
+
+# runtime user will need to be able to self-insert in /etc/passwd
+chmod g+rw /etc/passwd
+
+# no need for this script to remain in the image after running
+rm $0

--- a/scripts/ci
+++ b/scripts/ci
@@ -6,7 +6,7 @@ source $(dirname $0)/lib/debug_functions
 cd $(dirname $0)
 
 if [[ $5 = operator ]]; then
-   ./codegen-operator
+   test -d ../operators/go/submariner-operator || ./codegen-operator
    ./build-operator
 fi
 

--- a/scripts/lib/find_functions
+++ b/scripts/lib/find_functions
@@ -1,9 +1,8 @@
 function find_go_pkg_dirs() {
-
     local BASE EXCLUDED_PKG_DIRS FIND_EXCLUDE PACKAGE_DIRS
 
     BASE=${2:-.}
-    EXCLUDED_PKG_DIRS=${EXCLUDED_PKG_DIRS:-vendor test .git .trash-cache bin}
+    EXCLUDED_PKG_DIRS=${EXCLUDE_PKG_DIRS:-vendor test .git .trash-cache bin}
 
     for excldir in $EXCLUDED_PKG_DIRS; do
         FIND_EXCLUDE="-path ./$excldir -prune -o $FIND_EXCLUDE"

--- a/scripts/validate
+++ b/scripts/validate
@@ -7,10 +7,8 @@ cd $(dirname $0)/..
 
 source scripts/lib/find_functions
 
-# FIXME: This var name is different than in find_go_pkg_dirs fn
-EXCLUDE_PKG_DIRS=".git .trash-cache vendor bin"
-
-PACKAGES=$(find_go_pkg_dirs --no-trailing-dots "*.go")
+EXCLUDE_PKG_DIRS=".git .trash-cache vendor bin operators"
+PACKAGES="$(find_go_pkg_dirs --no-trailing-dots "*.go") operators/go/submariner-operator/pkg"
 
 if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     echo Incorrect formatting


### PR DESCRIPTION
Codegen was being forced on CI, this will avoid codegen step from being executed
as it's already checked in, saving valuable CI time.