### PR TITLE
Add linter to check no "Apply suggestions" commits

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,13 +15,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Verify no "Apply suggestions from code review" commits'
+      - name: 'Verify no "Apply suggestions from code review" commits foo'
         uses: tim-actions/commit-message-checker-with-regex@v0.3.1
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^(?!.*(apply suggestions from code review))'
           flags: 'i'
-          error: 'Commits addressing code review feedback should be squashed into the commits under review'
+          error: 'Commits addressing code review feedback should be squashed into the commits under review foo'
 
   code-gen:
     name: Submariner K8s API Code Generation

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,6 +5,24 @@ on:
   pull_request:
 
 jobs:
+  apply-suggestions-commits:
+    name: 'No "Apply suggestions from code review" Commits'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@v1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Verify no "Apply suggestions from code review" commits'
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^(?!.*(apply suggestions from code review))'
+          flags: 'i'
+          error: 'Commits addressing code review feedback should be squashed into the commits under review'
+
   code-gen:
     name: Submariner K8s API Code Generation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a linting job to verify that no commit message in a PR contains the
case insensitive string "Apply suggestions from code review". Commits
with exactly this title are generated by GitHub automatically when
proposed changes from code review are accepted from the GitHub UI. A
number of such commits have made it into various Submariner/* repos.

Commits addressing code review feedback should typically be squashed
into the commits under review, or made into well-commented discrete
commits.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>