### PR TITLE
Add Anchore vulnerability scanning on PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -125,6 +125,28 @@ jobs:
       - name: Run packagedoc-lint
         run: make packagedoc-lint
 
+  vulnerability-scan:
+    name: Vulnerability Scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Run Anchore vulnerability scanner
+        uses: anchore/scan-action@516844f15d82b6cdd0765b87aab79ed3ac006225
+        id: scan
+        with:
+          path: "."
+          fail-build: true
+          severity-cutoff: negligible
+      - name: Show Anchore scan SARIF report
+        if: always()
+        run: cat ${{ steps.scan.outputs.sarif }}
+      - name: Upload Anchore scan SARIF report
+        if: always()
+        uses: github/codeql-action/upload-sarif@0c670bbf0414f39666df6ce8e718ec5662c21e03
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+
   yaml-lint:
     name: YAML
     runs-on: ubuntu-latest

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,12 @@
+---
+ignore:
+  # False positive, CVE is actually about the C++ project protocolbuffers/protobuf
+  # https://github.com/anchore/grype/issues/558
+  - vulnerability: CVE-2015-5237
+    package:
+      name: google.golang.org/protobuf
+  # False positive, CVE is actually about the C++ project protocolbuffers/protobuf
+  # https://github.com/anchore/grype/issues/633
+  - vulnerability: CVE-2021-22570
+    package:
+      name: google.golang.org/protobuf


### PR DESCRIPTION
Add scanning of Go dependencies for known vulnerabilities.

Relates-to: #794
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>